### PR TITLE
Fix client config filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ dependencies {
 
 ## Configuration
 
-### `./config/developer-mode/client.settings.properties`
+### `./config/developer-mode/client.config.properties`
 
 ```properties
 # Theme for the loading screen


### PR DESCRIPTION
During runtime, the config/developer-mode directory contains client.config.properties, not client.settings.properties.